### PR TITLE
fix: update Copilot CLI version to 0.0.360 in CI workflow and README

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22.x] # Updated to your preferred Node.js version.
-        # Test against a list of known compatible versions and always check the latest.
-        copilot-version: ['0.0.359']
+        # Test against a list of known compatible versions
+        copilot-version: ['0.0.360']
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ This fork introduces two dedicated scripts:
 
 | Platform | Status | Tested Versions | Notes |
 |----------|--------|----------------|-------|
-| macOS    | ✅ Working | v0.0.359 | Fully tested and verified. |
-| Windows  | ✅ Working | v0.0.359 | Fully tested on PowerShell, WSL, and Git Bash. |
-| Linux    | ✅ Working | v0.0.359 | Verified via automated tests on Ubuntu. |
+| macOS    | ✅ Working | v0.0.360 | Verified via automated tests on macOS |
+| Windows  | ✅ Working | v0.0.360 | Fully tested on PowerShell, WSL, and Git Bash and automated tests on Windows |
+| Linux    | ✅ Working | v0.0.360 | Verified via automated tests on Ubuntu. |
 
 
 **Note:** This script performs text-based find-and-replace on minified JavaScript. Different Copilot CLI versions may have different internal structure. Always test with `--dry-run` first.
@@ -53,7 +53,8 @@ This fork introduces two dedicated scripts:
 - GitHub Copilot CLI version `0.0.356`. (They added new models: gpt-5.1,gpt-5.1-codex-mini,gpt-5.1-codex)
 - GitHub Copilot CLI version `0.0.357`. (They remove code for added models: gpt-5.1,gpt-5.1-codex-mini,gpt-5.1-codex? wierd...)
 - GitHub Copilot CLI version `0.0.358`. (They fix and restore code for added models: gpt-5.1,gpt-5.1-codex-mini,gpt-5.1-codex 🩷)
-- GitHub Copilot CLI version `0.0.359`. (Latest tested version)
+- GitHub Copilot CLI version `0.0.359`.
+- GitHub Copilot CLI version `0.0.360`. (Latest tested version)
 
 ### For Bash Script (`patch-models.sh`)
 - **Bash shell** (macOS, Linux, WSL)


### PR DESCRIPTION
This pull request updates the project to support and test against the latest GitHub Copilot CLI version, `0.0.360`, across all platforms. Documentation and CI configuration have been revised to reflect this change.

Platform and version support updates:

* Updated the tested Copilot CLI version to `0.0.360` for macOS, Windows, and Linux in the compatibility table in `README.md`, including notes about automated testing on all platforms.
* Added Copilot CLI version `0.0.360` as the latest tested version in the version history section of `README.md`.

Continuous integration configuration:

* Updated the CI workflow in `.github/workflows/ci-tests.yml` to test against Copilot CLI version `0.0.360` instead of `0.0.359`.