### PR TITLE
fix: update Copilot CLI version to 0.0.361 in CI workflow and README

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22.x] # Updated to your preferred Node.js version.
         # Test against a list of known compatible versions
-        copilot-version: ['0.0.360']
+        copilot-version: ['0.0.361']
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ This fork introduces two dedicated scripts:
 
 | Platform | Status | Tested Versions | Notes |
 |----------|--------|----------------|-------|
-| macOS    | ✅ Working | v0.0.360 | Verified via automated tests on macOS |
-| Windows  | ✅ Working | v0.0.360 | Fully tested on PowerShell, WSL, and Git Bash and automated tests on Windows |
-| Linux    | ✅ Working | v0.0.360 | Verified via automated tests on Ubuntu. |
+| macOS    | ✅ Working | v0.0.361 | Verified via automated tests on macOS |
+| Windows  | ✅ Working | v0.0.361 | Fully tested on PowerShell, WSL, and Git Bash and automated tests on Windows |
+| Linux    | ✅ Working | v0.0.361 | Verified via automated tests on Ubuntu. |
 
 
 **Note:** This script performs text-based find-and-replace on minified JavaScript. Different Copilot CLI versions may have different internal structure. Always test with `--dry-run` first.
@@ -54,7 +54,8 @@ This fork introduces two dedicated scripts:
 - GitHub Copilot CLI version `0.0.357`. (They remove code for added models: gpt-5.1,gpt-5.1-codex-mini,gpt-5.1-codex? wierd...)
 - GitHub Copilot CLI version `0.0.358`. (They fix and restore code for added models: gpt-5.1,gpt-5.1-codex-mini,gpt-5.1-codex 🩷)
 - GitHub Copilot CLI version `0.0.359`.
-- GitHub Copilot CLI version `0.0.360`. (Latest tested version)
+- GitHub Copilot CLI version `0.0.360`. 
+- GitHub Copilot CLI version `0.0.361`. (They added new model: Gemini 3 Pro. Latest tested version)
 
 ### For Bash Script (`patch-models.sh`)
 - **Bash shell** (macOS, Linux, WSL)


### PR DESCRIPTION
This pull request updates the project to support and document compatibility with GitHub Copilot CLI version `0.0.361`, including workflow and documentation changes. The main updates are version bumps and notes on new model support.

Compatibility and version updates:

* Updated the `copilot-version` matrix in `.github/workflows/ci-tests.yml` to test against version `0.0.361` instead of `0.0.360`.
* Updated the platform compatibility table in `README.md` to reflect testing and support for Copilot CLI version `0.0.361` across macOS, Windows, and Linux.

Documentation improvements:

* Added a note in `README.md` that Copilot CLI version `0.0.361` introduces support for the Gemini 3 Pro model and is the latest tested version.