### PR TITLE
fix: remove raptor-mini from default models in scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This fork introduces two dedicated scripts:
 - GitHub Copilot CLI version `0.0.360`. 
 - GitHub Copilot CLI version `0.0.361`. (They added new model: Gemini 3 Pro. Latest tested version)
 - GitHub Copilot CLI version `0.0.362`. (They fix some issues only)
-- GitHub Copilot CLI version `0.0.363`. (Opus 4.5, GPT-4.1 and GPT-5-Mini are now available in GitHub Copilot CLI Native so i add models they dont add by default (gpt-4o,grok-code-fast-1,raptor-mini,gemini-2.5-pro (pls remember to unlock new models in Copilot stetings page)))
+- GitHub Copilot CLI version `0.0.363`. (Opus 4.5, GPT-4.1 and GPT-5-Mini are now available in GitHub Copilot CLI Native so i add models they dont add by default (gpt-4o,grok-code-fast-1,gemini-2.5-pro (pls remember to unlock new models in Copilot settings page)))
 
 ### For Bash Script (`patch-models.sh`)
 - **Bash shell** (macOS, Linux, WSL)

--- a/patch-models.ps1
+++ b/patch-models.ps1
@@ -23,7 +23,7 @@
 param(
     [string]$File,
     [switch]$DryRun,
-    [string]$Models = "gpt-4o,grok-code-fast-1,raptor-mini,gemini-2.5-pro"
+    [string]$Models = "gpt-4o,grok-code-fast-1,gemini-2.5-pro"
 )
 
 # --- Main logic ---

--- a/patch-models.sh
+++ b/patch-models.sh
@@ -69,7 +69,7 @@ TARGET_FILE="${COPILOT_PATH}"
 BACKUP_SUFFIX=".bak.$(date +%Y%m%d-%H%M%S)"
 DRY_RUN=false
 # Default models to add; you can change or override with the --models flag
-MODELS_TO_ADD=("gpt-4o" "grok-code-fast-1" "raptor-mini" "gemini-2.5-pro") 
+MODELS_TO_ADD=("gpt-4o" "grok-code-fast-1" "gemini-2.5-pro") 
 
 # --- Colors ---
 RED='\033[0;31m'


### PR DESCRIPTION
This pull request updates the default set of AI models added by the patch scripts and documentation. The main change is the removal of the `raptor-mini` model from the list of models added by default in both the Bash and PowerShell scripts, as well as in the documentation.

**Model configuration updates:**

* Updated the default models in the `patch-models.sh` Bash script by removing `raptor-mini` from the `MODELS_TO_ADD` array.
* Updated the default models in the `patch-models.ps1` PowerShell script by removing `raptor-mini` from the `$Models` parameter.

**Documentation update:**

* Updated the `README.md` to reflect the removal of `raptor-mini` from the list of default models added for GitHub Copilot CLI version `0.0.363`.